### PR TITLE
Bug fix: Log to stderr, not stdout

### DIFF
--- a/lib/ecraft/logging_library/custom_formatter.rb
+++ b/lib/ecraft/logging_library/custom_formatter.rb
@@ -111,13 +111,13 @@ module Ecraft
         alias_method :color_for_severity_lighter, :time_color_for_severity
 
         def show_time?
-          # When STDOUT is redirected, we are likely running as a service with a syslog daemon already appending a timestamp to the
+          # When STDERR is redirected, we are likely running as a service with a syslog daemon already appending a timestamp to the
           # line (and two timestamps is redundant).
           tty?
         end
 
         def tty?
-          $stdout.tty?
+          $stderr.tty?
         end
       end
 

--- a/lib/ecraft/logging_library/logger.rb
+++ b/lib/ecraft/logging_library/logger.rb
@@ -14,7 +14,7 @@ module Ecraft
       def_delegator :logger, :progname, :name
 
       def initialize(name)
-        init($stdout)
+        init($stderr)
 
         logger.level = :info
         logger.progname = name

--- a/spec/ecraft/logging_library/loggable_spec.rb
+++ b/spec/ecraft/logging_library/loggable_spec.rb
@@ -33,16 +33,16 @@ module Ecraft
           end
 
           # DEBUG severity is not printed out by default.
-          it "does not print a message to STDOUT when sending the 'debug' message" do
-            expect { subject.logger.debug('debug blerp') }.to_not output.to_stdout
+          it "does not print a message to STDERR when sending the 'debug' message" do
+            expect { subject.logger.debug('debug blerp') }.to_not output.to_stderr
           end
 
-          it "prints a message to STDOUT when sending the 'info' message" do
-            expect { subject.logger.info('info blerp') }.to output(/info blerp/).to_stdout
+          it "prints a message to STDERR when sending the 'info' message" do
+            expect { subject.logger.info('info blerp') }.to output(/info blerp/).to_stderr
           end
 
-          it "prints a message to STDOUT when sending the 'warn' message" do
-            expect { subject.logger.warn('warn blerp') }.to output(/warn blerp/).to_stdout
+          it "prints a message to STDERR when sending the 'warn' message" do
+            expect { subject.logger.warn('warn blerp') }.to output(/warn blerp/).to_stderr
           end
         end
       end


### PR DESCRIPTION
I noticed this when piping some `puts`  output to a file, and the log output was also included.

@qzio / @smgt - does this play well enough with syslog in our platform/container setup? Does it capture both stdout and stderr?
